### PR TITLE
Forced use of uri 1.0.3

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,3 +9,6 @@ gem 'jemoji'
 # Security patch
 # REF: https://security.snyk.io/vuln/SNYK-RUBY-WEBRICK-8068535
 gem 'webrick', '1.9.1'
+# Security patch
+# REF: https://github.com/advisories/GHSA-22h5-pq3x-2gf2
+gem 'uri', '1.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -263,7 +263,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (0.13.0)
+    uri (1.0.3)
     webrick (1.9.1)
 
 PLATFORMS
@@ -273,7 +273,8 @@ DEPENDENCIES
   github-pages
   jekyll-github-metadata
   jemoji
+  uri (= 1.0.3)
   webrick (= 1.9.1)
 
 BUNDLED WITH
-   2.1.4
+   2.6.5


### PR DESCRIPTION
REF:
- https://github.com/advisories/GHSA-22h5-pq3x-2gf2
- https://www.cve.org/CVERecord?id=CVE-2025-27221
